### PR TITLE
fix: resolve icon thumbnail boxing, high-DPI blur, and escape dismiss…

### DIFF
--- a/src/launcher.h
+++ b/src/launcher.h
@@ -1406,11 +1406,19 @@ private:
             return DefWindowProcW(hwnd_, WM_KEYDOWN, key, lParam);
         }
         if (key == VK_ESCAPE) {
-            if (composing_) {
+            if (actionsOpen_) {
+                actionsOpen_ = false;
+                actionsPositioned_ = false;
+                ResetCaret();
+                InvalidateRect(hwnd_, nullptr, FALSE);
+            } else if (composing_) {
                 if (HIMC context = ImmGetContext(hwnd_)) {
                     ImmNotifyIME(context, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
                     ImmReleaseContext(hwnd_, context);
                 }
+            } else if (!input_.text.empty()) {
+                input_.Clear();
+                OnQueryChanged();
             } else {
                 Hide();
             }
@@ -1901,7 +1909,7 @@ private:
             iconPending_.insert(lookupPath);
             {
                 std::lock_guard<std::mutex> lock(iconMutex_);
-                iconQueue_.push_back({lookupPath, size});
+                iconQueue_.push_back({lookupPath, size, dpi_});
             }
             iconCv_.notify_one();
         }
@@ -1942,7 +1950,7 @@ private:
             auto result = std::make_unique<IconResult>();
             result->path = std::move(request.path);
             result->size = request.size;
-            if (wic) result->source = LoadIconSource(wic.Get(), result->path, request.size);
+            if (wic) result->source = LoadIconSource(wic.Get(), result->path, request.size, request.dpi);
             if (PostMessageW(hwnd_, kIconReadyMessage, 0, reinterpret_cast<LPARAM>(result.get()))) {
                 result.release();
             } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -617,6 +617,7 @@ std::vector<AppEntry> BuildAppIndex() {
 struct IconRequest {
     std::wstring path;
     UINT size = 0;
+    UINT dpi = 96;
 };
 
 struct IconResult {
@@ -625,32 +626,93 @@ struct IconResult {
     ComPtr<IWICBitmapSource> source;
 };
 
-// Runs on the icon worker thread. Extracts the shell icon, then materializes
-// the downscaled pixels into a small standalone bitmap so the cache never pins
-// the original 256px decode (which would cost ~256KB per cached icon).
+// Detects whether a 256x256 image returned by the shell is actually a synthetic
+// thumbnail plate (with an outer border box) around a small 32px/48px icon.
+bool IsBoxedThumbnail(IWICBitmap* bitmap) {
+    if (!bitmap) return false;
+    UINT width = 0, height = 0;
+    if (FAILED(bitmap->GetSize(&width, &height)) || width != 256 || height != 256) {
+        return false;
+    }
+    ComPtr<IWICBitmapLock> lock;
+    WICRect rect{0, 0, 256, 256};
+    if (FAILED(bitmap->Lock(&rect, WICBitmapLockRead, &lock))) {
+        return false;
+    }
+    UINT bufferSize = 0;
+    WICInProcPointer data = nullptr;
+    if (FAILED(lock->GetDataPointer(&bufferSize, &data)) || bufferSize < 256 * 256 * 4) {
+        return false;
+    }
+
+    // Windows Shell synthesizes a 1px border around the 256x256 canvas when wrapping small icons.
+    size_t edgeNonZero = 0;
+    const BYTE* pixels = data;
+    for (int x = 0; x < 256; ++x) {
+        if (pixels[(0 * 256 + x) * 4 + 3] > 0) ++edgeNonZero;
+        if (pixels[(255 * 256 + x) * 4 + 3] > 0) ++edgeNonZero;
+    }
+    for (int y = 1; y < 255; ++y) {
+        if (pixels[(y * 256 + 0) * 4 + 3] > 0) ++edgeNonZero;
+        if (pixels[(y * 256 + 255) * 4 + 3] > 0) ++edgeNonZero;
+    }
+    if (edgeNonZero <= 100) return false;
+
+    // If it has a perimeter border, check if the interior is mostly empty (< 14,000 non-zero pixels).
+    size_t totalNonZero = 0;
+    for (int i = 0; i < 256 * 256; ++i) {
+        if (pixels[i * 4 + 3] > 0) {
+            ++totalNonZero;
+            if (totalNonZero >= 14000) return false;
+        }
+    }
+    return true;
+}
+
+// Runs on the icon worker thread. Extracts the highest quality shell icon,
+// downscales using WIC Fant box filter, and stamps display DPI for 1:1 pixel rendering.
 ComPtr<IWICBitmapSource> LoadIconSource(IWICImagingFactory* wic,
-    const std::wstring& path, UINT size) {
+    const std::wstring& path, UINT size, UINT dpi) {
     ComPtr<IWICBitmapSource> source;
     ComPtr<IShellItemImageFactory> imageFactory;
     if (SUCCEEDED(SHCreateItemFromParsingName(path.c_str(), nullptr,
             IID_PPV_ARGS(&imageFactory)))) {
         HBITMAP bitmap = nullptr;
-        // Request the jumbo 256px icon so we downscale a sharp source
-        // instead of upscaling the small 32px variant.
-        if (FAILED(imageFactory->GetImage({256, 256},
-                SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap))) {
-            imageFactory->GetImage({static_cast<LONG>(size), static_cast<LONG>(size)},
-                SIIGBF_BIGGERSIZEOK, &bitmap);
-        }
-        if (bitmap) {
+        // 1. Try 256x256 jumbo icon first. For apps with high-res icon assets,
+        // this supplies the sharpest master source for downscaling.
+        if (SUCCEEDED(imageFactory->GetImage({256, 256},
+                SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK, &bitmap)) && bitmap) {
             ComPtr<IWICBitmap> converted;
             if (SUCCEEDED(wic->CreateBitmapFromHBITMAP(bitmap, nullptr,
                     WICBitmapUsePremultipliedAlpha, &converted))) {
-                source = converted;
+                if (!IsBoxedThumbnail(converted.Get())) {
+                    source = converted;
+                }
             }
             DeleteObject(bitmap);
+            bitmap = nullptr;
+        }
+
+        // 2. If 256px failed or was a synthetic boxed thumbnail around a small icon,
+        // query native standard tiers (48px or 32px) directly without thumbnail framing.
+        if (!source) {
+            if (FAILED(imageFactory->GetImage({48, 48}, SIIGBF_ICONONLY, &bitmap)) || !bitmap) {
+                if (FAILED(imageFactory->GetImage({32, 32}, SIIGBF_ICONONLY, &bitmap)) || !bitmap) {
+                    imageFactory->GetImage({32, 32}, SIIGBF_RESIZETOFIT, &bitmap);
+                }
+            }
+            if (bitmap) {
+                ComPtr<IWICBitmap> converted;
+                if (SUCCEEDED(wic->CreateBitmapFromHBITMAP(bitmap, nullptr,
+                        WICBitmapUsePremultipliedAlpha, &converted))) {
+                    source = converted;
+                }
+                DeleteObject(bitmap);
+            }
         }
     }
+
+    // 3. Fallback to SHGetFileInfo if IShellItemImageFactory was unavailable.
     if (!source) {
         SHFILEINFOW info{};
         if (SHGetFileInfoW(path.c_str(), 0, &info, sizeof(info),
@@ -663,6 +725,21 @@ ComPtr<IWICBitmapSource> LoadIconSource(IWICImagingFactory* wic,
         }
     }
     if (!source) return nullptr;
+
+    // 4. Downscale cleanly to target pixel size with WIC's Fant filter (area-averaging box filter).
+    // Stamp display DPI so Direct2D renders 1:1 on the physical pixel grid without fractional resampling blur.
+    UINT width = 0, height = 0;
+    if (SUCCEEDED(source->GetSize(&width, &height)) && width == size && height == size) {
+        ComPtr<IWICBitmap> copy;
+        if (SUCCEEDED(wic->CreateBitmapFromSource(source.Get(), WICBitmapCacheOnLoad, &copy))) {
+            if (dpi > 0) {
+                copy->SetResolution(static_cast<double>(dpi), static_cast<double>(dpi));
+            }
+            return copy;
+        }
+        return source;
+    }
+
     ComPtr<IWICBitmapScaler> scaler;
     ComPtr<IWICBitmap> scaled;
     if (SUCCEEDED(wic->CreateBitmapScaler(&scaler)) &&
@@ -670,6 +747,9 @@ ComPtr<IWICBitmapSource> LoadIconSource(IWICImagingFactory* wic,
             WICBitmapInterpolationModeFant)) &&
         SUCCEEDED(wic->CreateBitmapFromSource(scaler.Get(), WICBitmapCacheOnLoad,
             &scaled))) {
+        if (dpi > 0) {
+            scaled->SetResolution(static_cast<double>(dpi), static_cast<double>(dpi));
+        }
         return scaled;
     }
     return source;


### PR DESCRIPTION
## Description

Resolves icon display flaws and fixes launcher dismissal behavior:

- Detect synthetic 256px thumbnail plates (1px outer border around small icons) and query native unboxed tiers (48px/32px) directly.
- Pass display DPI into icon worker and stamp resolution on scaled WIC bitmaps to eliminate fractional resampling blur in Direct2D.
- Dismiss actions popup and clear non-empty search queries on Escape before hiding launcher window.

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance optimization
- [ ] Documentation update
- [ ] Refactoring / cleanup

## How Has This Been Tested?

- [x] Core tests passed (`ctest --test-dir build -C Release`)
- [x] Visual Studio build succeeded (`Takeoff.sln` Release x64)
- [x] Manual test on Windows (Windows 10 / 11)
- [x] UI smoke test passed (`py tests/ui_smoke.py build/Release/TakeoffUiTests.exe`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified that no external dependencies or bloat were introduced
- [x] New and existing tests pass locally